### PR TITLE
Fix in rev.cmake

### DIFF
--- a/cmake/rev.cmake
+++ b/cmake/rev.cmake
@@ -108,5 +108,4 @@ if (NOT GIT_COMMIT_ID)
 endif ()
 
 # configure packaging
-set ( ENV{SOURCE_DATE_EPOCH} "${SOURCE_DATE_EPOCH}" ) # that makes builds reproducable
 configure_file ( "${columnar_SOURCE_DIR}/cmake/CPackOptions.cmake.in" "${columnar_BINARY_DIR}/config/CPackOptions.cmake" @ONLY )


### PR DESCRIPTION
```
set ( ENV{SOURCE_DATE_EPOCH} "${SOURCE_DATE_EPOCH}" ) # that makes builds reproducable
```

is wrong since the variable is never set before, so the env. var. gets empty while the env. var. in its turn gets set before.

clang 16+ are sensitive to empty SOURCE_DATE_EPOCH, e.g.:

```
    Run Build Command(s):/usr/bin/ninja -v cmTC_56e17 && [1/2] /usr/lib/llvm-16/bin/clang++    -o CMakeFiles/cmTC_56e17.dir/testCXXCompiler.cxx.o -c /columnar/build/FastPFOR-build/FastPFOR_populate-prefix/src/FastPFOR_populate-build/CMakeFiles/CMakeScratch/TryCompile-DAiMJC/testCXXCompiler.cxx
    FAILED: CMakeFiles/cmTC_56e17.dir/testCXXCompiler.cxx.o
    /usr/lib/llvm-16/bin/clang++    -o CMakeFiles/cmTC_56e17.dir/testCXXCompiler.cxx.o -c /columnar/build/FastPFOR-build/FastPFOR_populate-prefix/src/FastPFOR_populate-build/CMakeFiles/CMakeScratch/TryCompile-DAiMJC/testCXXCompiler.cxx
    error: environment variable 'SOURCE_DATE_EPOCH' ('') must be a non-negative decimal integer <= 253402300799
    ninja: build stopped: subcommand failed.
```