### PR TITLE
ci: update pack_publish workflow to include 'pack_publish' tag support

### DIFF
--- a/.github/workflows/pack_publish.yml
+++ b/.github/workflows/pack_publish.yml
@@ -15,6 +15,7 @@ on:
       - columnar-*
     tags:
       - 'release*'
+      - 'pack_publish'
 
 # cancels the previous workflow run when a new one appears in the same branch (e.g. master or a PR's branch)
 concurrency:
@@ -34,7 +35,7 @@ jobs:
       should_continue: ${{ steps.check-should-continue.outputs.should_continue }}
     if: |
       (github.event_name == 'pull_request' && (contains(github.event.pull_request.labels.*.name, 'pack') || contains(github.event.pull_request.labels.*.name, 'publish')))
-      || (github.event_name == 'push')
+      || ( github.event_name == 'push' && ( startsWith( github.ref, 'refs/heads/columnar-' ) || contains( github.ref, 'refs/tags/pack_publish' ) ) )
       || (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' && github.ref == 'refs/heads/master' && github.event.workflow_run.event != 'schedule')
     steps:
       - name: Checkout repository
@@ -52,17 +53,23 @@ jobs:
       - name: Check if we should continue packing
         id: check-should-continue
         run: |
-          # Continue if version was updated or if we have the "pack" label on PR
+          # Continue if version was updated, if we have the "pack" label on PR, or if target is "release"
           if [[ "${{ steps.semver-tagger.outputs.version_updated }}" == "true" ]]; then
             echo "Continuing because version was updated"
+            echo "should_continue=true" >> $GITHUB_OUTPUT
+          elif [[ "${{ steps.semver-tagger.outputs.target }}" == "release" ]]; then
+            echo "Continuing because target is release"
             echo "should_continue=true" >> $GITHUB_OUTPUT
           elif [[ "${{ github.event_name }}" == "pull_request" && "${{ contains(github.event.pull_request.labels.*.name, 'pack') }}" == "true" ]]; then
             echo "Continuing because PR has 'pack' label"
             echo "should_continue=true" >> $GITHUB_OUTPUT
+          elif [[ "${{ contains(github.ref, 'refs/tags/pack_publish') }}" == "true" ]]; then
+            echo "Continuing because commit has 'pack_publish' tag"
+            echo "should_continue=true" >> $GITHUB_OUTPUT
           else
-          echo "Skipping packing because version wasn't updated and there's no 'pack' label"
+            echo "Skipping packing because version wasn't updated, target is not release, and there's no 'pack' label or tag"
             echo "should_continue=false" >> $GITHUB_OUTPUT
-          fi          
+          fi
       - run: |
           echo "# Packing and publishing all for commit ${{ github.sha }}" >> $GITHUB_STEP_SUMMARY
           echo "* Commit URL: [${{ github.sha }}](/${{ github.repository }}/commit/${{ github.sha }})" >> $GITHUB_STEP_SUMMARY
@@ -176,6 +183,7 @@ jobs:
         (github.event_name == 'pull_request' && (contains(github.event.pull_request.labels.*.name, 'publish')))
         || (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success')
         || (github.event_name == 'push' && startsWith(github.ref, 'refs/heads/columnar-'))
+        || (github.event_name == 'push' && contains(github.ref, 'refs/tags/pack_publish'))
         || (needs.pack.outputs.target == 'release')
       )
     outputs:


### PR DESCRIPTION
Enhanced the pack_publish workflow to recognize the 'pack_publish' tag, allowing the workflow to continue packing if this tag is present. Updated conditional logic to check for the 'release' target and improved comments for clarity.