### PR TITLE
fix(ci): lower glibc version to 2.27 for bionic compatibility

### DIFF
--- a/.github/workflows/embedding_build_template.yml
+++ b/.github/workflows/embedding_build_template.yml
@@ -80,10 +80,10 @@ jobs:
         run: |
           # Set Docker image based on architecture
           if [[ "${{ inputs.arch }}" == "aarch64" ]]; then
-            docker_image="ghcr.io/manticoresoftware/rust-min-libc:aarch64-rust1.86.0-glibc2.28-openssl1.1.1k"
+            docker_image="ghcr.io/manticoresoftware/rust-min-libc:aarch64-rust1.86.0-glibc2.27-openssl1.1.1k"
             extra=""
           else
-            docker_image="ghcr.io/manticoresoftware/rust-min-libc:amd64-rust1.86.0-glibc2.28-openssl1.1.1k"
+            docker_image="ghcr.io/manticoresoftware/rust-min-libc:amd64-rust1.86.0-glibc2.27-openssl1.1.1k"
             extra=""
           fi
 


### PR DESCRIPTION
- Update Docker images to use glibc 2.27 instead of 2.28
- Ensure compatibility with Ubuntu Bionic environment