### PR TITLE
fix: fixed a crash on binary quantization with dimensions that aren't multiples of 8

### DIFF
--- a/knn/quantizer.cpp
+++ b/knn/quantizer.cpp
@@ -407,7 +407,7 @@ void BinaryQuantizer_c::Pack ( const Span_T<float> & dVector, Span_T<uint8_t> & 
 		int iOff = 0;
 		for ( int j = 7; j >= 0; j-- )
 		{
-			if ( dVector[i + j] > 0.0f )
+			if ( i + j < dVector.size() && dVector[i + j] > 0.0f )
 				uByte |= ( 1 << iOff );
 
 			iOff++;

--- a/manticore_src.txt
+++ b/manticore_src.txt
@@ -1,1 +1,1 @@
-GIT_REPOSITORY https://github.com/manticoresoftware/manticoresearch.git GIT_TAG 91a1ed5
+GIT_REPOSITORY https://github.com/manticoresoftware/manticoresearch.git GIT_TAG 57a3856


### PR DESCRIPTION
fix: fixed a crash on binary quantization with dimensions that aren't multiples of 8