### PR TITLE
chore: minor change in embeddings/README.md

### DIFF
--- a/embeddings/README.md
+++ b/embeddings/README.md
@@ -11,4 +11,3 @@ cargo build --lib --release
 ```bash
 g++ -o test examples/test.cpp -Ltarget/release -lmanticore_knn_embeddings -I. -lpthread -ldl -std=c++17
 ```
-


### PR DESCRIPTION
Embeddings Rust lib is not a POC anymore.