### PR TITLE
VX2 type mismatch in quantizer.cpp

### DIFF
--- a/knn/quantizer.cpp
+++ b/knn/quantizer.cpp
@@ -317,17 +317,18 @@ int BinaryQuantizer_c::Quantize ( const Span_T<float> & dVector, float fMin, flo
 	size_t uLimit = dVector.size() & ~7;
 	for ( ; i < uLimit; i += 8 )
 	{
-		__m256 iVec = _mm256_loadu_ps ( &dVector[i] );
-		iVec = _mm256_sub_ps ( iVec, iMinVec );
-		iVec = _mm256_mul_ps ( iVec, iDivVec );
-		iVec = _mm256_round_ps ( iVec, _MM_FROUND_TO_NEAREST_INT );
-		iVec = _mm256_cvtps_epi32(iVec);       
+		__m256 fVec = _mm256_loadu_ps ( &dVector[i] );
+		fVec = _mm256_sub_ps ( fVec, iMinVec );
+		fVec = _mm256_mul_ps ( fVec, iDivVec );
+		fVec = _mm256_round_ps ( fVec, _MM_FROUND_TO_NEAREST_INT );
+
+		__m256i iVec = _mm256_cvtps_epi32 ( fVec );
 		iVec = _mm256_max_epi32 ( iVec, _mm256_setzero_si256() );
 		iVec = _mm256_min_epi32 ( iVec, _mm256_set1_epi32(15) );
 
 		iSumVec = _mm256_add_epi32 ( iSumVec, iVec );
 
-		__m128i iLow = _mm256_castsi256_si128(iVec);
+		__m128i iLow = _mm256_castsi256_si128 ( iVec );
 		__m128i iHigh = _mm256_extracti128_si256 ( iVec, 1 );
 		__m128i iPack16 = _mm_packs_epi32 ( iLow, iHigh );
 		__m128i iPack8 = _mm_packus_epi16 ( iPack16, iPack16 );


### PR DESCRIPTION
_mm256_cvtps_epi32 returns __m256i, but the result was incorrectly assigned to a __m256 variable, causing compilation errors with GCC 15 and stricter SIMD type checking.